### PR TITLE
Support Chrome 76

### DIFF
--- a/src/log-to-output.js
+++ b/src/log-to-output.js
@@ -85,17 +85,18 @@ function install(on, filter) {
   on('before:browser:launch', browserLaunchHandler)
 }
 
+function isChrome(browser) {
+  return browser.family === 'chrome' || ['chrome', 'chromium', 'canary'].includes(browser.name)
+}
+
 function browserLaunchHandler(browser = {}, args) {
-  const isChrome = ['chrome'].includes(browser.family) || browser.name === 'chrome'
-  if (!isChrome) {
+  if (!isChrome(browser)) {
     return log(` [cypress-log-to-output] Warning: An unsupported browser family was used, output will not be logged to console: ${browser.family}`)
   }
 
   const rdp = 40000 + Math.round(Math.random() * 25000)
 
-  if (isChrome) {
-    args.push(`--remote-debugging-port=${rdp}`)
-  }
+  args.push(`--remote-debugging-port=${rdp}`)
 
   log(' [cypress-log-to-output] Attempting to connect to Chrome Debugging Protocol')
 

--- a/src/log-to-output.js
+++ b/src/log-to-output.js
@@ -86,13 +86,14 @@ function install(on, filter) {
 }
 
 function browserLaunchHandler(browser = {}, args) {
-  if (!['chrome'].includes(browser.family)) {
+  const isChrome = ['chrome'].includes(browser.family) || browser.name === 'chrome'
+  if (!isChrome) {
     return log(` [cypress-log-to-output] Warning: An unsupported browser family was used, output will not be logged to console: ${browser.family}`)
   }
 
   const rdp = 40000 + Math.round(Math.random() * 25000)
 
-  if (browser.family === 'chrome') {
+  if (isChrome) {
     args.push(`--remote-debugging-port=${rdp}`)
   }
 


### PR DESCRIPTION
In Chrome 76, `browser` doesn't contain a `family` element:

```js
{ name: 'chrome',
  displayName: 'Chrome',
  version: '76.0.3809.132',
  path: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
  majorVersion: '76',
  isHeadless: false,
  isHeaded: true }
```

This PR updates the library's check for whether we're using Chrome to support either `browser.family` or `browser.name`.

Fixes https://github.com/flotwig/cypress-log-to-output/issues/3.
