### PR TITLE
feat: add option to record log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ module.exports = (on, config) => {
 }
 ```
 
+## Recording Logs
+
+If you want to record the logs internally, you can use the `recordLog` option:
+
+```js
+module.exports = (on, config) => {
+  /** the rest of your plugins... **/
+  const options = { recordLogs: true };
+  require('cypress-log-to-output').install(on, filterCallback, options)
+}
+```
+
+The logs will be stored in an internal buffer. They can be accessed using the `getLogs` exported function. 
+The buffer can be cleared using the `clearLogs` exported function.
+
 ## Disabling debug info
 
 You can remove the lines beginning with `[cypress-log-to-output]` by passing `-cypress-log-to-output` in the `DEBUG` environment variable.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module.exports = (on, config) => {
 
 ## Recording Logs
 
-If you want to record the logs internally, you can use the `recordLog` option:
+If you want to record the logs internally, you can use the `recordLogs` option:
 
 ```js
 module.exports = (on, config) => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,3 +1,3 @@
 module.exports = (on) => {
-  require('../../src/log-to-output').install(on)
+  require('../../src/log-to-output').install(on, () => true, { recordLogs: true})
 }


### PR DESCRIPTION
Add the configurable option to store the messages that would have been printed to output in an internal buffer. The stored logs are exposed through a getter.

This feature enables accessing the logs from other plugins.

I'd be happy to change whatever you think is necessary.

Thanks!