### PR TITLE
Add option to disable logging to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ makes sense when `recordLogs` is `true`.
 
 ```js
 module.exports = (on, config) => {
-  const options = { recordLogs: true, logToOutput: true };
+  const options = { recordLogs: true, logToOutput: false };
   require('cypress-log-to-output').install(on, filterCallback, options)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -65,15 +65,40 @@ module.exports = (on, config) => {
 If you want to record the logs internally, you can use the `recordLogs` option:
 
 ```js
+const logToOutput = require('cypress-log-to-output');
+
 module.exports = (on, config) => {
   /** the rest of your plugins... **/
   const options = { recordLogs: true };
-  require('cypress-log-to-output').install(on, filterCallback, options)
+  logToOutput.install(on, filterCallback, options)
+
+  on('after:spec', () => {
+    const logs = logToOutput.getLogs();
+
+    // do something with the logs ...
+
+    logToOutput.clearLogs();
+  });  
 }
 ```
 
 The logs will be stored in an internal buffer. They can be accessed using the `getLogs` exported function. 
 The buffer can be cleared using the `clearLogs` exported function.
+
+## Disable logging to output
+
+If you don't want the logs to show up in the stdout, you can set
+the `logToOutput` option to `false`. This option can be used on its own, but mostly
+makes sense when `recordLogs` is `true`.
+
+```js
+module.exports = (on, config) => {
+  const options = { recordLogs: true, logToOutput: true };
+  require('cypress-log-to-output').install(on, filterCallback, options)
+}
+```
+
+Note that debug messages are not affected and must be disabled explicitly (see below).
 
 ## Disabling debug info
 

--- a/src/log-to-output.js
+++ b/src/log-to-output.js
@@ -2,6 +2,7 @@ const CDP = require('chrome-remote-interface')
 const chalk = require('chalk')
 
 let eventFilter
+let logToOutput = true
 let recordLogs
 
 let messageLog = [];
@@ -26,11 +27,14 @@ function debugLog(msg) {
     return
   }
 
-  log(`[cypress-log-to-output] ${msg}`)
+  // debug messages should be logged even if logToOutput is false
+  log(`[cypress-log-to-output] ${msg}`, true)
 }
 
-function log(msg) {
-  console.log(msg)
+function log(msg, forceDebug = false) {
+  if (logToOutput || forceDebug) {
+    console.log(msg)
+  }
 }
 
 function logEntry(params) {
@@ -100,9 +104,15 @@ function logConsole(params) {
   }
 }
 
-function install(on, filter, options = {}) {
+function install(on, filter, options = {
+  logToOutput: true,
+  recordLogs: false
+}) {
   eventFilter = filter;
   recordLogs = options.recordLogs;
+  if (options.logToOutput === false) {
+    logToStdout = false
+  }
   on('before:browser:launch', browserLaunchHandler)
 }
 

--- a/src/log-to-output.js
+++ b/src/log-to-output.js
@@ -2,7 +2,7 @@ const CDP = require('chrome-remote-interface')
 const chalk = require('chalk')
 
 let eventFilter
-let logToOutput = true
+let logToOutput
 let recordLogs
 
 let messageLog = [];
@@ -109,10 +109,9 @@ function install(on, filter, options = {
   recordLogs: false
 }) {
   eventFilter = filter;
+  logToOutput = options.logToOutput;
   recordLogs = options.recordLogs;
-  if (options.logToOutput === false) {
-    logToStdout = false
-  }
+  
   on('before:browser:launch', browserLaunchHandler)
 }
 


### PR DESCRIPTION
If recordLogs is true, it can be useful to not actual log anything to stdout. If you set logToOutput=false, it disables logging, except for debug messages.

Fixes #18 